### PR TITLE
Adds Travis CI integration, resolves #13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+sudo: required
+dist: trusty
+
+services:
+  - docker
+
+matrix:
+  fast_finish: true
+
+  include:
+    - os: linux
+
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update && sudo apt-get -y install docker-ce
+  - docker build -t $TRAVIS_REPO_SLUG-$TRAVIS_COMMIT -f Dockerfile.cpu .
+
+script:
+  - docker run --ipc=host --rm $TRAVIS_REPO_SLUG-$TRAVIS_COMMIT

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Unofficial PyTorch (and ONNX) 3D video classification models and weights pre-trained on IG-65M (65MM Instagram videos).
 The official Facebook Research Caffe2 model and weights are available [here](https://github.com/facebookresearch/vmz).
 
+[![Build Status](https://travis-ci.org/moabitcoin/ig65m-pytorch.svg?branch=master)](https://travis-ci.org/moabitcoin/ig65m-pytorch)
+
 
 ## PyTorch and ONNX Models :trophy:
 


### PR DESCRIPTION
For #13.

Let's see if we can simply let Travis CI build and then run our docker image and container, respectively.

Travis env vars from https://docs.travis-ci.com/user/environment-variables/

Only Linux workers for now; we could add macOS later if we really want to.