### PR TITLE
Disables grads in extract tool

### DIFF
--- a/ig65m/cli/extract.py
+++ b/ig65m/cli/extract.py
@@ -67,14 +67,15 @@ def main(args):
 
     features = []
 
-    for inputs in tqdm(loader, total=len(dataset) // args.batch_size):
-        inputs = inputs.to(device)
+    with torch.no_grad():
+        for inputs in tqdm(loader, total=len(dataset) // args.batch_size):
+            inputs = inputs.to(device)
 
-        outputs = model(inputs)
-        outputs = outputs.data.cpu().numpy()
+            outputs = model(inputs)
+            outputs = outputs.data.cpu().numpy()
 
-        for output in outputs:
-            features.append(output)
+            for output in outputs:
+                features.append(output)
 
     np.save(args.features, np.array(features), allow_pickle=False)
     print("🍪 Done", file=sys.stderr)


### PR DESCRIPTION
We forgot to disable gradient computation

https://pytorch.org/docs/stable/autograd.html#torch.autograd.no_grad

I just noticed we require quite a lot of memory and stumbled upon this. With this changeset applied our memory consumption should go down by a lot (In my case multiple GBs).