### PR TITLE
Match the num_class in PyTorch Hub with Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We provide convenient [PyTorch Hub](https://pytorch.org/docs/stable/hub.html) in
 >>> torch.hub.list("moabitcoin/ig65m-pytorch")
 ['r2plus1d_34_32_ig65m', 'r2plus1d_34_32_kinetics', 'r2plus1d_34_8_ig65m', 'r2plus1d_34_8_kinetics']
 >>>
->>> model = torch.hub.load("moabitcoin/ig65m-pytorch", "r2plus1d_34_32_ig65m", num_classes=359, pretrained=True)
+>>> model = torch.hub.load("moabitcoin/ig65m-pytorch", "r2plus1d_34_32_ig65m", num_classes=487, pretrained=True)
 ```
 
 ### Tools


### PR DESCRIPTION
[TL;DR] I simply changed the num_class in the PyTorch Hub example to match with the model description.



First of all, thanks for this great work. While I read the Readme file, I found one logical error. So, I made a pull request to correct this, if my understanding is correct. 

Specifically, as specified in line #109, "Models fine-tuned on Kinetics have 400 classes, the plain IG65 models 487 (32 clips), and 359 (8 clips) classes", but the PyTorch Hub example sets "359" classes even for the "r2plus1d_34_32_ig65m" model.

Please check the details below.