### PR TITLE
Channel mismatched with README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We provide convenient [PyTorch Hub](https://pytorch.org/docs/stable/hub.html) in
 >>> torch.hub.list("moabitcoin/ig65m-pytorch")
 ['r2plus1d_34_32_ig65m', 'r2plus1d_34_32_kinetics', 'r2plus1d_34_8_ig65m', 'r2plus1d_34_8_kinetics']
 >>>
->>> model = torch.hub.load("moabitcoin/ig65m-pytorch", "r2plus1d_34_32_ig65m", num_classes=487, pretrained=True)
+>>> model = torch.hub.load("moabitcoin/ig65m-pytorch", "r2plus1d_34_32_ig65m", num_classes=359, pretrained=True)
 ```
 
 ### Tools
@@ -106,7 +106,7 @@ We provide converted `.pth` and `.pb` PyTorch and ONNX weights, respectively.
 
 Notes
 - ONNX models provided here have not been optimized for inference.
-- Models fine-tuned on Kinetics have 400 classes, the plain IG65 models 487 (32 clips), and 359 (8 clips) classes.
+- Models fine-tuned on Kinetics have 400 classes, the plain IG65 models 359 (32 clips), and 487 (8 clips) classes.
 - For models fine-tuned on Kinetics you can use the labels from [here](https://github.com/Showmax/kinetics-downloader/blob/68bd8bc3b9e30da83db9e34cb7d867dcda705cb4/resources/classes.json).
 - For plain IG65 models there is no label map available.
 - Official Facebook Research Caffe2 models are [here](https://github.com/facebookresearch/vmz).

--- a/ig65m/models.py
+++ b/ig65m/models.py
@@ -20,7 +20,7 @@ def r2plus1d_34_8_ig65m(num_classes, pretrained=False, progress=False):
       pretrained: If True, loads weights pretrained on 65 million Instagram videos
       progress: If True, displays a progress bar of the download to stderr
     """
-    assert not pretrained or num_classes == 359, "pretrained on 359 classes"
+    assert not pretrained or num_classes == 487, "pretrained on 487 classes"
     return r2plus1d_34(num_classes=num_classes, arch="r2plus1d_34_8_ig65m",
                        pretrained=pretrained, progress=progress)
 
@@ -33,7 +33,7 @@ def r2plus1d_34_32_ig65m(num_classes, pretrained=False, progress=False):
       pretrained: If True, loads weights pretrained on 65 million Instagram videos
       progress: If True, displays a progress bar of the download to stderr
     """
-    assert not pretrained or num_classes == 487, "pretrained on 487 classes"
+    assert not pretrained or num_classes == 359, "pretrained on 359 classes"
     return r2plus1d_34(num_classes=num_classes, arch="r2plus1d_34_32_ig65m",
                        pretrained=pretrained, progress=progress)
 

--- a/ig65m/models.py
+++ b/ig65m/models.py
@@ -20,7 +20,7 @@ def r2plus1d_34_8_ig65m(num_classes, pretrained=False, progress=False):
       pretrained: If True, loads weights pretrained on 65 million Instagram videos
       progress: If True, displays a progress bar of the download to stderr
     """
-    assert not pretrained or num_classes == 487, "pretrained on 487 classes"
+    assert not pretrained or num_classes == 359, "pretrained on 359 classes"
     return r2plus1d_34(num_classes=num_classes, arch="r2plus1d_34_8_ig65m",
                        pretrained=pretrained, progress=progress)
 
@@ -33,7 +33,7 @@ def r2plus1d_34_32_ig65m(num_classes, pretrained=False, progress=False):
       pretrained: If True, loads weights pretrained on 65 million Instagram videos
       progress: If True, displays a progress bar of the download to stderr
     """
-    assert not pretrained or num_classes == 359, "pretrained on 359 classes"
+    assert not pretrained or num_classes == 487, "pretrained on 487 classes"
     return r2plus1d_34(num_classes=num_classes, arch="r2plus1d_34_32_ig65m",
                        pretrained=pretrained, progress=progress)
 


### PR DESCRIPTION
Hi, @daniel-j-h

I now tried with 'r2plus1d_34_32_ig65m' model with 487 classes (after this pull request https://github.com/moabitcoin/ig65m-pytorch/pull/30 ), but I failed with an assert. I think either this part, or the description in README (see below) is incorrect:
`Models fine-tuned on Kinetics have 400 classes, the plain IG65 models 487 (32 clips), and 359 (8 clips) classes.`

Please check the output dimension and make some appropriate changes.

Regards,
- Yunseok